### PR TITLE
Fixed sleep: added HKCategoryTypeIdentifier, timeZone and sleepStatus

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -24,7 +24,7 @@ public class CapacitorHealthkit: CAPPlugin {
         case "bloodGlucose":
             return HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.bloodGlucose)!
         case "sleepAnalysis":
-            return HKObjectType.categoryType(forIdentifier: .sleepAnalysis)!
+            return HKObjectType.categoryType(forIdentifier: HKCategoryTypeIdentifier.sleepAnalysis)!
         case "workoutType":
             return HKWorkoutType.workoutType()
         default:
@@ -43,7 +43,7 @@ public class CapacitorHealthkit: CAPPlugin {
             case "duration":
                 types.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.appleExerciseTime)!)
             case "activity":
-                types.insert(HKObjectType.categoryType(forIdentifier: .sleepAnalysis)!)
+                types.insert(HKObjectType.categoryType(forIdentifier: HKCategoryTypeIdentifier.sleepAnalysis)!)
                 types.insert(HKWorkoutType.workoutType())
             case "calories":
                 types.insert(HKQuantityType.quantityType(forIdentifier: HKQuantityTypeIdentifier.activeEnergyBurned)!)


### PR DESCRIPTION
As I mentioned in https://github.com/Ad-Scientiam/capacitor-healthkit/issues/3 it seemed like sleepAnalysis wasn't working for me. I'm not 100% sure, but having looked at the code it seemed like .sleepAnalysis was the only sampleType that didn't have its TypeIdentifier as the object it was referencing.

Hopefully this fixes that, so that sleep data can be queried.

Closes #3 