### PR TITLE
Capacitor 3: target iOS 12

### DIFF
--- a/CapacitorHealthkit.podspec
+++ b/CapacitorHealthkit.podspec
@@ -8,6 +8,6 @@
     s.author = 'Ad Scientiam'
     s.source = { :git => 'https://github.com/Ad-Scientiam/capacitor-healthkit.git', :tag => s.version.to_s }
     s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-    s.ios.deployment_target  = '11.0'
+    s.ios.deployment_target  = '12.0'
     s.dependency 'Capacitor'
   end


### PR DESCRIPTION
This is the only _required_ change to make this plugin work with capacitor 3, see [upgrade instructions](https://capacitorjs.com/docs/updating/plugins/3-0#set-ios-deployment-target-to-120).

