### PR TITLE
:bug: don't crash if no data was returned

### DIFF
--- a/ios/Plugin/CapacitorHealthkitPlugin.swift
+++ b/ios/Plugin/CapacitorHealthkitPlugin.swift
@@ -272,6 +272,9 @@ public class CapacitorHealthkitPlugin: CAPPlugin {
 
     func generateOutput(sampleName: String, results: [HKSample]?) -> [[String: Any]]? {
         var output: [[String: Any]] = []
+        if results == nil {
+            return output
+        }
         for result in results! {
             if sampleName == "sleepAnalysis" {
                 guard let sample = result as? HKCategorySample else {


### PR DESCRIPTION
The crash log included:

```
0   PerfoodCapacitorHealthkit     	0x0000000103367ef0 Swift runtime failure: Unexpectedly found nil while unwrapping an Optional value + 0 (CapacitorHealthkitPlugin.swift:0)
1   PerfoodCapacitorHealthkit     	0x0000000103367ef0 specialized CapacitorHealthkitPlugin.generateOutput(sampleName:results:) + 7516 (CapacitorHealthkitPlugin.swift:275)
```

So I'm confident that checking for `nil` before iterating should fix the crash.